### PR TITLE
add test_packages to img_test_vm.sh as argument

### DIFF
--- a/src/img/tester.py
+++ b/src/img/tester.py
@@ -555,6 +555,7 @@ class ImageTester(object):
                 self.commands.scpto(self.test_script, '/var/tmp/test_script.sh') 
                 self.commands.ssh(['chmod', '+x', '/var/tmp/test_script.sh'])
                 test_comm = ['/var/tmp/test_script.sh']
+                test_comm.extend(self.test_packages.keys())
                 self.result = self.commands.ssh(test_comm, user=self.test_user, ignore_error=True)
                 print "Test result is %s" % self.result
         except:

--- a/src/scripts/img_test_vm.sh
+++ b/src/scripts/img_test_vm.sh
@@ -14,10 +14,14 @@ done
 
 TEST_PACKAGES=$@
 
+# we don't know how to handle patterns!
+if [[ "$TEST_PACKAGES" == *@* ]]; then
+  TEST_PACKAGES=""
+fi
+
+
 if [ -z "$TEST_PACKAGES" ]; then
-
   TEST_PACKAGES="$(rpm -qal | grep '/tests.xml' | xargs -r rpm -qf)"
-
 fi
 
 


### PR DESCRIPTION
this allows to execute just one test package. In case the test package
is a pattern, the img_test_vm.sh runs all available tests on the device.
