### PR TITLE
[img_web] Fix a bug in template selection form

### DIFF
--- a/src/img_web/templates/app/upload.html
+++ b/src/img_web/templates/app/upload.html
@@ -18,6 +18,8 @@
             var disid = $(dissel).attr('id');
             $('#id_'+enid).removeAttr("disabled");
             $('#id_'+disid).attr("disabled","disabled");
+            if (disid == 'template') { $('#id_'+disid).val("None") }
+            else if(disid == 'ksfile') { $('#id_'+disid).val("") }
         });
         $("#uploadform").submit( function () {
            $('#id_ksfile , #id_template').each(function(){ $(this).removeAttr("disabled")});


### PR DESCRIPTION
If template is selected from drop down menu and after that user selects
own file the form has both of these options. Form validation fails, since
only one of them can be selected. Fix this by clearing disselected field.