### PR TITLE
Switch build_image mic_opts separator from comma to colon

### DIFF
--- a/src/img/common.py
+++ b/src/img/common.py
@@ -32,7 +32,7 @@ def worker_config(config=None, conffile="/etc/imager/img.conf"):
 
     if config.has_option(section, "mic_opts"):
         extra_opts = config.get(section, "mic_opts")
-        extra_opts = extra_opts.split(",")
+        extra_opts = extra_opts.split(":")
         conf["extra_opts"] = extra_opts
 
     return conf

--- a/src/img_boss/build_image.conf
+++ b/src/img_boss/build_image.conf
@@ -25,11 +25,11 @@ use_kvm = no
 ict = mic
 
 ; Additional mic options may be sepecified
-; comma separated Example mic_opts = --save-kernel,--use_comps
+; colon separated Example mic_opts = --save-kernel:--use_comps
 ; mic > 0.13 replaces --compress-disk-image option with --pack-to
-mic_opts = --pack-to=@NAME@.tar.bz2,--copy-kernel
-; mic < 0.13 and mic2 
-; mic_opts = --compress-disk-image=bz2,--save-kernel
+mic_opts = --pack-to=@NAME@.tar.bz2:--copy-kernel
+; mic < 0.13 and mic2
+; mic_opts = --compress-disk-image=bz2:--save-kernel
 
 ; A temporary directory where imager will create qcow2 overlay files. Only used
 ; in the case where mic2 is run inside KVM. It is recommended to be a fast


### PR DESCRIPTION
Mic's own --record-pkgs argument takes a comma separated list,
e.g. --record-pkgs=url,name,content,license so we need to pick a
different separator for build_image's mic_opts setting.