### PR TITLE
Wip suggested device

### DIFF
--- a/src/img_web/app/forms.py
+++ b/src/img_web/app/forms.py
@@ -251,7 +251,11 @@ class ImageJobForm(forms.Form):
                                                  help_text=\
                               "Packages: comma separated list of tags "\
                               "to describe the image built.")
-
+    device = forms.CharField(
+        label="Device",
+        required=False,
+        widget=forms.TextInput(attrs={'readonly': 'readonly'}),
+    )
 
     def __init__(self, *args, **kwargs):
         super(ImageJobForm, self).__init__(*args, **kwargs)
@@ -269,6 +273,8 @@ class ImageJobForm(forms.Form):
                         attrs[key] = val
                     elif re.match(r'^#.*?DisplayName:.+$', line):
                         name = line.split(":")[1].strip()
+                    elif re.match(r'^#.*?Device:.+$', line):
+                        attrs['data-device'] = line.split(":")[1].strip()
 
             self.fields['template'].choices.append((templatename , name, attrs))
 

--- a/src/img_web/app/forms.py
+++ b/src/img_web/app/forms.py
@@ -251,8 +251,8 @@ class ImageJobForm(forms.Form):
                                                  help_text=\
                               "Packages: comma separated list of tags "\
                               "to describe the image built.")
-    device = forms.CharField(
-        label="Device",
+    devicemodel = forms.CharField(
+        label="Device model",
         required=False,
         widget=forms.TextInput(attrs={'readonly': 'readonly'}),
     )
@@ -273,8 +273,8 @@ class ImageJobForm(forms.Form):
                         attrs[key] = val
                     elif re.match(r'^#.*?DisplayName:.+$', line):
                         name = line.split(":")[1].strip()
-                    elif re.match(r'^#.*?Device:.+$', line):
-                        attrs['data-device'] = line.split(":")[1].strip()
+                    elif re.match(r'^#.*?DeviceModel:.+$', line):
+                        attrs['data-devicemodel'] = line.split(":")[1].strip()
 
             self.fields['template'].choices.append((templatename , name, attrs))
 

--- a/src/img_web/app/forms.py
+++ b/src/img_web/app/forms.py
@@ -256,6 +256,11 @@ class ImageJobForm(forms.Form):
         required=False,
         widget=forms.TextInput(attrs={'readonly': 'readonly'}),
     )
+    devicevariant = forms.CharField(
+        label="Device variant",
+        required=False,
+        widget=forms.TextInput(attrs={'readonly': 'readonly'}),
+    )
 
     def __init__(self, *args, **kwargs):
         super(ImageJobForm, self).__init__(*args, **kwargs)
@@ -275,6 +280,8 @@ class ImageJobForm(forms.Form):
                         name = line.split(":")[1].strip()
                     elif re.match(r'^#.*?DeviceModel:.+$', line):
                         attrs['data-devicemodel'] = line.split(":")[1].strip()
+                    elif re.match(r'^#.*?DeviceVariant:.+$', line):
+                        attrs['data-devicevariant'] = line.split(":")[1].strip()
 
             self.fields['template'].choices.append((templatename , name, attrs))
 

--- a/src/img_web/app/forms.py
+++ b/src/img_web/app/forms.py
@@ -262,14 +262,13 @@ class ImageJobForm(forms.Form):
             attrs = {}
             with open(template, 'r') as tf:
                 for line in tf:
-                    if re.match(r'^#.*?DisplayName:.+$', line):
+                    match = re.match(r'^#.*?Suggested([^:]*):(.*)$', line)
+                    if match:
+                        key = 'data-' + match.group(1).lower()
+                        val = match.group(2).strip()
+                        attrs[key] = val
+                    elif re.match(r'^#.*?DisplayName:.+$', line):
                         name = line.split(":")[1].strip()
-                    if re.match(r'^#.*?SuggestedFeatures:.+$', line):
-                        attrs["data-features"] = line.split(":")[1].strip()
-                    if re.match(r'^#.*?SuggestedArchitecture:.+$', line):
-                        attrs["data-architecture"] = line.split(":")[1].strip()
-                    if re.match(r'^#.*?SuggestedImageType:.+$', line):
-                        attrs["data-imagetype"] = line.split(":")[1].strip()
 
             self.fields['template'].choices.append((templatename , name, attrs))
 

--- a/src/img_web/app/views.py
+++ b/src/img_web/app/views.py
@@ -150,6 +150,10 @@ def submit(request):
             archtoken = "i586"
         tokenmap["ARCH"] = archtoken
 
+        devicetoken = jobdata.get('device')
+        if devicetoken:
+            tokenmap['DEVICE'] = devicetoken
+
         tokens_list = []
         extra_repos_tmp = []
         for token, tokenvalue in tokenmap.items(): 

--- a/src/img_web/app/views.py
+++ b/src/img_web/app/views.py
@@ -152,7 +152,10 @@ def submit(request):
 
         devicemodeltoken = jobdata.get('devicemodel')
         if devicemodeltoken:
-            tokenmap['DEVICE'] = devicemodeltoken
+            tokenmap['DEVICEMODEL'] = devicemodeltoken
+        devicevarianttoken = jobdata.get('devicevariant')
+        if devicevarianttoken:
+            tokenmap['DEVICEVARIANT'] = devicevarianttoken
 
         tokens_list = []
         extra_repos_tmp = []

--- a/src/img_web/app/views.py
+++ b/src/img_web/app/views.py
@@ -150,9 +150,9 @@ def submit(request):
             archtoken = "i586"
         tokenmap["ARCH"] = archtoken
 
-        devicetoken = jobdata.get('device')
-        if devicetoken:
-            tokenmap['DEVICE'] = devicetoken
+        devicemodeltoken = jobdata.get('devicemodel')
+        if devicemodeltoken:
+            tokenmap['DEVICE'] = devicemodeltoken
 
         tokens_list = []
         extra_repos_tmp = []

--- a/src/img_web/templates/app/upload.html
+++ b/src/img_web/templates/app/upload.html
@@ -119,6 +119,14 @@
             {{ jobform.devicemodel }}
             </td>
         </tr>
+        <tr>
+          <td>
+            {{ jobform.devicevariant.label_tag }}
+          </td>
+          <td>
+            {{ jobform.devicevariant }}
+          </td>
+        </tr>
         </table>
     </fieldset>
 </table>

--- a/src/img_web/templates/app/upload.html
+++ b/src/img_web/templates/app/upload.html
@@ -113,10 +113,10 @@
         </tr>
         <tr>
             <td>
-            {{ jobform.device.label_tag }}
+            {{ jobform.devicemodel.label_tag }}
             </td>
             <td>
-            {{ jobform.device }}
+            {{ jobform.devicemodel }}
             </td>
         </tr>
         </table>

--- a/src/img_web/templates/app/upload.html
+++ b/src/img_web/templates/app/upload.html
@@ -111,6 +111,14 @@
             {{ jobform.architecture }}
             </td>
         </tr>
+        <tr>
+            <td>
+            {{ jobform.device.label_tag }}
+            </td>
+            <td>
+            {{ jobform.device }}
+            </td>
+        </tr>
         </table>
     </fieldset>
 </table>


### PR DESCRIPTION
With this proof of concept, selecting a .ks template which contains a '# Device: foo' line, will:

 1) set the device input element text to 'foo'
 2) on submission set tokenmap['DEVICE'] = 'foo'

from where the regular tokenmap machinery will pass it on to mic.

For the passing along to mic part this follows the implementation of the ARCH token (an attribute directly on ImageJobForm, rather than a Token).

For the .ks parsing part the implementation I chose to be closer to DisplayName parsing as in my opinion the device is tied directly to the .ks template, while image type, architecture and features can make sense to allow for user choice.

NB: I made the SuggestedFoo parsing generic but this may not be desired.

Directions to take from here:
  - when using Token class the generic SuggestedFoo code doesn't work because tokens live in a separate form so the jquery should be something liike $("[name=form-0-DEVICE"]).
  - completely hide the device from the user (but be sure to keep submitting it in the form)
  - restrict SuggestedFoo parsing to whitelisted fields