### PR TITLE
Safely invoke commands over SSH

### DIFF
--- a/src/img/tester.py
+++ b/src/img/tester.py
@@ -13,6 +13,7 @@
 #~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
+import pipes
 import hashlib
 import subprocess as sub
 from multiprocessing import Process, TimeoutError
@@ -194,7 +195,7 @@ class Commands(object):
         ssh_comm = copy(self.sshbase)
         ssh_comm.extend(["-l%s" % user])
         ssh_comm.extend(self.sopts)
-        ssh_comm.extend(command)
+        ssh_comm.extend([pipes.quote(arg) for arg in command])
         try:
             self.run(ssh_comm)
         except sub.CalledProcessError:
@@ -588,7 +589,7 @@ class ImageTester(object):
                 else:
                     print "trying to get any test results"
                     self.commands.scpfrom("/tmp/results/*", self.results_dir)
-                    self.commands.ssh(['rm', '-rf', '/tmp/results/*'])
+                    self.commands.ssh(['sh', '-c', 'rm -rf /tmp/results/*'])
             except:
                 pass
 

--- a/src/img/worker.py
+++ b/src/img/worker.py
@@ -16,6 +16,7 @@
 """MIC2 mic-image-creator wrapper"""
 
 import os
+import pipes
 import subprocess as sub
 from multiprocessing import Process, TimeoutError
 import time, datetime
@@ -250,7 +251,7 @@ class Commands(object):
         """
         ssh_comm = copy(self.sshbase)
         ssh_comm.extend(self.sopts)
-        ssh_comm.extend(command)
+        ssh_comm.extend([pipes.quote(arg) for arg in command])
         self.run(ssh_comm)
 
     def is_lvm(self, img):
@@ -351,7 +352,7 @@ class Commands(object):
             mic_comm.append('--config=%s' % job_args.ksfile_name)
         elif self.ict == "mic":
             mic_comm.append('%s' % job_args.image_type)
-            mic_comm.append('"%s"' % job_args.ksfile_name)
+            mic_comm.append('%s' % job_args.ksfile_name)
 
         mic_comm.append('--arch=%s' % job_args.arch)
         mic_comm.append('--outdir=%s' % job_args.outdir)

--- a/src/img_web/app/views.py
+++ b/src/img_web/app/views.py
@@ -140,9 +140,6 @@ def submit(request):
                 else:
                     tokenmap["RELEASEPATTERN"] = ":/%s" % tokenvalue
 
-            if " " in tokenvalue:
-                tokenvalue = '"%s"' % tokenvalue
-
             tokenmap[token.name] = tokenvalue
 
         archtoken = jobdata['architecture']


### PR DESCRIPTION
It is common misunderstanding that SSH accepts CMD [ARGS...]. Actually
it joins all positional arguments and passes the resulting single string
to sh -c.