### PR TITLE
Fixed job log scrolling on page load

### DIFF
--- a/src/img_web/templates/app/job_details.html
+++ b/src/img_web/templates/app/job_details.html
@@ -48,7 +48,7 @@
 </iframe>
 <script type="text/javascript">
 x=document.getElementById("logframe");
-x.onload = function () { x.contentWindow.scrollTo(0,x.contentWindow.scrollMaxY); }
+x.onload = function () { x.contentWindow.scrollTo(0, x.contentWindow.document.body.scrollHeight); }
 var refTimeoutID = window.setInterval('x=document.getElementById("logframe");x.src=x.src;', 20000);
 </script>
 </div>


### PR DESCRIPTION
contentWindow.scrollMaxY returns null on Chrome
contentWindow.document.body.scrollHeight works with both Chrome and Firefox